### PR TITLE
Fixed - Upper_body_detection segfault, memory corruption

### DIFF
--- a/detection/rgbd_detectors/rwth_upper_body_detector/include/AncillaryMethods.h
+++ b/detection/rgbd_detectors/rwth_upper_body_detector/include/AncillaryMethods.h
@@ -58,8 +58,8 @@ public:
 //    static void RenderBBox2DWithScore(const Vector<double> &bbox, QImage& image, int r, int g, int b, int lineWidth);
 
 
-    static Vector<double> getGaussian1D(double sigma, double precision);
-    static Vector<double> conv1D(const Vector<double>& vec, const Vector<double>& kernel);
+    static getGaussian1D(double sigma, double precision, Vector<double>& vecin);
+    static void conv1D(const Vector<double>& vec, const Vector<double>& kernel);
 
     static void MorphologyErode(Matrix<double> &img);
     static void MorphologyDilate(Matrix<double> &img);
@@ -95,7 +95,7 @@ public:
 
 
     ///////////////// Segmentation part /////////////////////////////////////////
-    static Matrix<double> conv1D(Matrix<double> &im, Vector<double> &kernel, bool dirFlag);
+    static void conv1D(Matrix<double> &im, Vector<double> &kernel, bool dirFlag);
 
 
     ////////// LM & Curve Detectors ////////////////////////////////////////////

--- a/detection/rgbd_detectors/rwth_upper_body_detector/include/AncillaryMethods.h
+++ b/detection/rgbd_detectors/rwth_upper_body_detector/include/AncillaryMethods.h
@@ -58,7 +58,7 @@ public:
 //    static void RenderBBox2DWithScore(const Vector<double> &bbox, QImage& image, int r, int g, int b, int lineWidth);
 
 
-    static getGaussian1D(double sigma, double precision, Vector<double>& vecin);
+    static void getGaussian1D(double sigma, double precision, Vector<double>& vecin);
     static void conv1D(const Vector<double>& vec, const Vector<double>& kernel);
 
     static void MorphologyErode(Matrix<double> &img);

--- a/detection/rgbd_detectors/rwth_upper_body_detector/include/AncillaryMethods.h
+++ b/detection/rgbd_detectors/rwth_upper_body_detector/include/AncillaryMethods.h
@@ -59,7 +59,7 @@ public:
 
 
     static void getGaussian1D(double sigma, double precision, Vector<double>& vecin);
-    static void conv1D(const Vector<double>& vec, const Vector<double>& kernel);
+    static void conv1D(Vector<double>& vec, const Vector<double>& kernel);
 
     static void MorphologyErode(Matrix<double> &img);
     static void MorphologyDilate(Matrix<double> &img);

--- a/detection/rgbd_detectors/rwth_upper_body_detector/include/detector.h
+++ b/detection/rgbd_detectors/rwth_upper_body_detector/include/detector.h
@@ -50,8 +50,9 @@ private:
     //          close_range_BBoxes  -   Bounding boxes over ROIs
     //          distances           -
     ///////////////////////////////////////////////////////////////////////
-    Vector<Vector<double> > EvaluateTemplate(const Matrix<double> &upper_body_template, const Matrix<double> &depth_map,
-                                             Vector<Vector<double> > &close_range_BBoxes, Vector<Vector<double> > distances);
+    void EvaluateTemplate(const Matrix<double> &upper_body_template, const Matrix<double> &depth_map,
+                                             Vector<Vector<double> > &close_range_BBoxes, Vector<Vector<double> > distances, 
+                                             Vector<Vector<double> > &result);
 
     ///////////////////////////////////////////////////////////////////////
     // PreprocessROIs:

--- a/detection/rgbd_detectors/rwth_upper_body_detector/src/AncillaryMethods.cpp
+++ b/detection/rgbd_detectors/rwth_upper_body_detector/src/AncillaryMethods.cpp
@@ -337,12 +337,12 @@ double AncillaryMethods::DistanceToPlane(const Vector<double>& point, const Vect
 //    painter.drawLine(x,y+h, x+w,y+h);
 //}
 
-Vector<double> AncillaryMethods::getGaussian1D(double sigma, double precision)
+void AncillaryMethods::getGaussian1D(double sigma, double precision, Vector<double>& vecin)
 {
 
     Vector<double> kernel;
     int size = 1 + 2*ceil(precision*sigma);
-    kernel.setSize(size);
+    vecin.setSize(size);
     int center = size/2.0;
 
     double x;
@@ -351,19 +351,17 @@ Vector<double> AncillaryMethods::getGaussian1D(double sigma, double precision)
     for (int i = 0; i < size; i++)
     {
         x = i-center;
-        kernel(i) = exp(x*x/(-2.0*sigma*sigma))/(sigma*sqrt(2.0*M_PI));
-        sum +=kernel(i);
+        vecin(i) = exp(x*x/(-2.0*sigma*sigma))/(sigma*sqrt(2.0*M_PI));
+        sum +=vecin(i);
     }
 
     for (int i = 0; i < size; i++)
     {
-        kernel(i) /=sum;
+        vecin(i) /=sum;
     }
-
-    return kernel;
 }
 
-Vector<double> AncillaryMethods::conv1D(const Vector<double> &vec, const Vector<double> &kernel)
+void AncillaryMethods::conv1D(const Vector<double> &vec, const Vector<double> &kernel)
 {
     int kernelSize = kernel.getSize();
     int kCenter = floor(kernelSize/2.0);
@@ -395,7 +393,7 @@ Vector<double> AncillaryMethods::conv1D(const Vector<double> &vec, const Vector<
         }
     }
 
-    return result;
+    vec = result;
 }
 
 void AncillaryMethods::MorphologyErode(Matrix<double> &img)
@@ -703,7 +701,7 @@ void AncillaryMethods::compute_rectangle(Vector<double>& main4D, Vector<double>&
 
 
 
-Matrix<double> AncillaryMethods::conv1D(Matrix<double>& im, Vector<double>& kernel, bool dirFlag)
+void AncillaryMethods::conv1D(Matrix<double>& im, Vector<double>& kernel, bool dirFlag)
 {
 
     // dirFalg == true --> in x dir,
@@ -754,7 +752,7 @@ Matrix<double> AncillaryMethods::conv1D(Matrix<double>& im, Vector<double>& kern
         }
     }
 
-    return result;
+    im = result;
 }
 
 
@@ -784,7 +782,9 @@ void AncillaryMethods::ExtractSlopsOnBorder(const Matrix<double>& image, Vector<
     }
 
     //    Vector<double> ys = ys;
-    ys = AncillaryMethods::conv1D(ys, AncillaryMethods::getGaussian1D(3,1));
+    Vector<double> tmp;
+    AncillaryMethods::getGaussian1D(3, 1, tmp);
+    AncillaryMethods::conv1D(ys, tmp);
 
     for(int i=0; i<ys.getSize()-1; ++i)
         slopes(i) = ys(i+1) - ys(i);

--- a/detection/rgbd_detectors/rwth_upper_body_detector/src/AncillaryMethods.cpp
+++ b/detection/rgbd_detectors/rwth_upper_body_detector/src/AncillaryMethods.cpp
@@ -361,7 +361,7 @@ void AncillaryMethods::getGaussian1D(double sigma, double precision, Vector<doub
     }
 }
 
-void AncillaryMethods::conv1D(const Vector<double> &vec, const Vector<double> &kernel)
+void AncillaryMethods::conv1D(Vector<double> &vec, const Vector<double> &kernel)
 {
     int kernelSize = kernel.getSize();
     int kCenter = floor(kernelSize/2.0);

--- a/detection/rgbd_detectors/rwth_upper_body_detector/src/KConnectedComponentLabeler.cpp
+++ b/detection/rgbd_detectors/rwth_upper_body_detector/src/KConnectedComponentLabeler.cpp
@@ -314,7 +314,14 @@ KConnectedComponentLabeler::KNode::KNode()
 
 KConnectedComponentLabeler::KNode::~KNode()
 {
-
+    if(this->sgNext != NULL){
+        delete this->sgNext;
+        this->sgNext = NULL;
+	}
+	if(this->ngNext != NULL){
+        delete this->ngNext;
+        this->ngNext = NULL;
+	}
 }
 
 
@@ -354,7 +361,11 @@ KConnectedComponentLabeler::KLinkedList::~KLinkedList()
 					ptr3 = ptr2;
 					ptr2 = ptr2->sgNext;
 				} else if( ptr1->sgNext != NULL ) {
-					delete ptr2;
+					if(ptr2 != NULL){
+                        delete ptr2;
+                        ptr2 = NULL;
+                    }
+
 					if( ptr3 != NULL )
 						ptr3->sgNext=NULL;
 					ptr2 = ptr1;
@@ -364,7 +375,10 @@ KConnectedComponentLabeler::KLinkedList::~KLinkedList()
 			while(ptr1->sgNext !=NULL);
 			
 			ptr1=ptr1->ngNext;
-			delete ptr2;
+			if(ptr2 != NULL){
+                delete ptr2;
+                ptr2 = NULL;
+            }
 			ptr2=ptr1;
 			ptr3=ptr1;
 		}

--- a/detection/rgbd_detectors/rwth_upper_body_detector/src/KConnectedComponentLabeler.cpp
+++ b/detection/rgbd_detectors/rwth_upper_body_detector/src/KConnectedComponentLabeler.cpp
@@ -317,11 +317,11 @@ KConnectedComponentLabeler::KNode::~KNode()
     if(this->sgNext != NULL){
         delete this->sgNext;
         this->sgNext = NULL;
-	}
-	if(this->ngNext != NULL){
+    }
+    if(this->ngNext != NULL){
         delete this->ngNext;
         this->ngNext = NULL;
-	}
+    }
 }
 
 
@@ -348,42 +348,42 @@ KConnectedComponentLabeler::KLinkedList::KLinkedList()
 
 KConnectedComponentLabeler::KLinkedList::~KLinkedList()
 {
-	KNode* ptr1 = header;
-	KNode* ptr2 = header;
-	KNode* ptr3 = header;
-	
-	if( header != NULL ) {
-		do 
-		{
-			do 
-			{
-				if (ptr2->sgNext != NULL){
-					ptr3 = ptr2;
-					ptr2 = ptr2->sgNext;
-				} else if( ptr1->sgNext != NULL ) {
-					if(ptr2 != NULL){
+    KNode* ptr1 = header;
+    KNode* ptr2 = header;
+    KNode* ptr3 = header;
+
+    if( header != NULL ) {
+        do
+        {
+            do
+            {
+                if (ptr2->sgNext != NULL){
+                    ptr3 = ptr2;
+                    ptr2 = ptr2->sgNext;
+                } else if( ptr1->sgNext != NULL ) {
+                    if(ptr2 != NULL){
                         delete ptr2;
                         ptr2 = NULL;
                     }
 
-					if( ptr3 != NULL )
-						ptr3->sgNext=NULL;
-					ptr2 = ptr1;
-					ptr3 = ptr1;
-				}
-			}
-			while(ptr1->sgNext !=NULL);
-			
-			ptr1=ptr1->ngNext;
-			if(ptr2 != NULL){
+                    if( ptr3 != NULL )
+                        ptr3->sgNext=NULL;
+                    ptr2 = ptr1;
+                    ptr3 = ptr1;
+                }
+            }
+            while(ptr1->sgNext !=NULL);
+
+            ptr1=ptr1->ngNext;
+            if(ptr2 != NULL){
                 delete ptr2;
                 ptr2 = NULL;
             }
-			ptr2=ptr1;
-			ptr3=ptr1;
-		}
-		while(ptr1!=NULL);
-	}
+            ptr2=ptr1;
+            ptr3=ptr1;
+        }
+        while(ptr1!=NULL);
+    }
 }
 
 void KConnectedComponentLabeler::KLinkedList::InsertData(int data)

--- a/detection/rgbd_detectors/rwth_upper_body_detector/src/detector.cpp
+++ b/detection/rgbd_detectors/rwth_upper_body_detector/src/detector.cpp
@@ -73,7 +73,7 @@ void Detector::ProcessFrame(const Camera &camera_origin, const Matrix<double> &d
 
 
 
-    detected_bounding_boxes = EvaluateTemplate(upper_body_template, depth_map, close_range_BBoxes, distances);
+    EvaluateTemplate(upper_body_template, depth_map, close_range_BBoxes, distances, detected_bounding_boxes);
 }
 
 void Detector::ComputeFreespace(const Camera& camera,
@@ -126,10 +126,12 @@ void Detector::ComputeFreespace(const Camera& camera,
                 int pos_z = (int)round(z / step_z);
 
 //                occ_map(pos_x, pos_z) += z*(log(z) / log_2);
-                occ_map(pos_x, pos_z) += z;
+                if( 0 < pos_x && pos_x < x_bins && 0 < pos_z && pos_z < z_bins ){
+                    occ_map(pos_x, pos_z) += z;
 
-                mat_2D_pos_x.data()[j] = pos_x;
-                mat_2D_pos_y.data()[j] = pos_z;
+                    mat_2D_pos_x.data()[j] = pos_x;
+                    mat_2D_pos_y.data()[j] = pos_z;
+                }
             }
         }
     }
@@ -137,9 +139,10 @@ void Detector::ComputeFreespace(const Camera& camera,
 //    occ_map.WriteToTXT("before.txt");
     
     
-     Vector<double> kernel = AncillaryMethods::getGaussian1D(2,3);
-     occ_map = AncillaryMethods::conv1D(occ_map, kernel, false);
-     occ_map = AncillaryMethods::conv1D(occ_map, kernel, true);
+     Vector<double> kernel;
+     AncillaryMethods::getGaussian1D(2, 3, kernel);
+     AncillaryMethods::conv1D(occ_map, kernel, false);
+     AncillaryMethods::conv1D(occ_map, kernel, true);
 
 // occ_map.WriteToTXT("after.txt");
  
@@ -194,7 +197,7 @@ void Detector::ExtractPointsInROIs(/*Vector<Vector<Vector<double> > > &all_point
         if(mat_2D_pos_x.data()[i] >= 0)
         {
             roi_ind = labeled_ROIs(mat_2D_pos_x.data()[i], mat_2D_pos_y.data()[i])-1;
-            if(roi_ind > -1)
+            if(roi_ind > -1 && (roi_ind < all_ROIs.getSize()))
             {
 //                all_points_in_ROIs(pos_in_proj).pushBack(Vector<double>(point_cloud.X(i), point_cloud.Y(i), point_cloud.Z(i)));
                 all_ROIs(roi_ind).has_any_point = true;
@@ -235,10 +238,11 @@ void Detector::ExtractPointsInROIs(/*Vector<Vector<Vector<double> > > &all_point
     }
 }
 
-Vector<Vector<double> >  Detector::EvaluateTemplate(const Matrix<double> &upper_body_template,
+void  Detector::EvaluateTemplate(const Matrix<double> &upper_body_template,
                                                         const Matrix<double> &depth_map,
                                                         Vector<Vector<double> > &close_range_BBoxes,
-                                                        Vector<Vector<double> > distances)
+                                                        Vector<Vector<double> > distances,
+                                                        Vector<Vector<double> > &result_caller)
 {
     int stride = Globals::evaluation_stride;
     int nr_scales = Globals::evaluation_nr_scales;
@@ -248,7 +252,6 @@ Vector<Vector<double> >  Detector::EvaluateTemplate(const Matrix<double> &upper_
     int int_half_template_size = Globals::template_size / 2;
     double double_half_template_size = Globals::template_size / 2.0;
 
-    Vector<Vector<double> > final_result;
 
     // generate the scales
     Vector<double> all_scales(nr_scales, 1.0);
@@ -490,8 +493,7 @@ Vector<Vector<double> >  Detector::EvaluateTemplate(const Matrix<double> &upper_
                 }
             }
         }
-        AncillaryMethods::GreedyNonMaxSuppression(result, Globals::evaluation_greedy_NMS_overlap_threshold, Globals::evaluation_greedy_NMS_threshold, upper_body_template, final_result);
+        AncillaryMethods::GreedyNonMaxSuppression(result, Globals::evaluation_greedy_NMS_overlap_threshold, Globals::evaluation_greedy_NMS_threshold, upper_body_template, result_caller);
     }
 //    roi_img.WriteToTXT("roi_img.txt");
-    return final_result;
 }

--- a/detection/rgbd_detectors/rwth_upper_body_detector/src/main.cpp
+++ b/detection/rgbd_detectors/rwth_upper_body_detector/src/main.cpp
@@ -188,8 +188,8 @@ void callback(const ImageConstPtr &depth, const GroundPlane::ConstPtr &gp, const
     cv_depth_ptr = cv_bridge::toCvCopy(depth);
     img_depth_ = cv_depth_ptr->image;
     Matrix<double> matrix_depth(info->width, info->height);
-    for (int r = 0;r < 480;r++){
-        for (int c = 0;c < 640;c++) {
+    for (int r = 0;r < info->height;r++){
+        for (int c = 0;c < info->width;c++) {
             matrix_depth(c, r) = img_depth_.at<float>(r,c);
         }
     }


### PR DESCRIPTION
This is a patch about issue#10. Most segfault are caused by double free. This patch fixed some programming level bugs without compromising function.

NOTE: The app still crashed time and again, the "respawn='true'" still need in the launch file. I guess the bugs locate in the function EvaluateTemplate() in file detector.cpp. Will continue struggle with it...