### PR TITLE
Fix crash on startup of upper_body_detector

### DIFF
--- a/detection/rgbd_detectors/rwth_upper_body_detector/src/main.cpp
+++ b/detection/rgbd_detectors/rwth_upper_body_detector/src/main.cpp
@@ -270,7 +270,7 @@ void callback(const ImageConstPtr &depth, const GroundPlane::ConstPtr &gp, const
     }
 
     // Creating a ros image with the detection results an publishing it
-    if(vis && abs((depth->header.stamp - color_image->header.stamp).toSec()) < 0.2) {  // only if color image is not outdated (not using a synchronizer!)
+    if(vis && color_image && abs((depth->header.stamp - color_image->header.stamp).toSec()) < 0.2) {  // only if color image is not outdated (not using a synchronizer!)
         // Check for suppported image format
         if(color_image->encoding == "rgb8" || color_image->encoding == "bgr8") {
             ROS_DEBUG("Publishing result image for upper-body detector");


### PR DESCRIPTION
If the upper_body_detector is initialized before the rgbd sensor and the
depth image is received before the rgb image (as is the case with a
kinect v1 using openni1 driver), color_image is an empty smart pointer
and thus trying to access a member causes a segfault.