### PR TITLE
Fixing detection remapping so detections are actually published to rviz for openni 1

### DIFF
--- a/launch/spencer_people_tracking_launch/launch/tracking_single_rgbd_sensor.launch
+++ b/launch/spencer_people_tracking_launch/launch/tracking_single_rgbd_sensor.launch
@@ -37,7 +37,7 @@
     <group>
         <!-- Remap input topics of detectors from "depth" to "depth_registered" in case we are using the OpenNi 1 driver (for MS Kinect).
              Necessary because OpenNi 1 does not publish both the registered and unregistered depth images (as OpenNi 2 does), and we want to keep depth registration enabled. -->
-        <remap from="/spencer/sensors/rgbd_front_top/depth/image_rect" to="/spencer/sensors/rgbd_front_top/depth_registered/image_rect"  if="$(arg use_openni1)"/>
+        <remap from="/spencer/sensors/rgbd_front_top/depth/image_rect" to="/spencer/sensors/rgbd_front_top/depth_registered/hw_registered/image_rect"  if="$(arg use_openni1)"/>
         <remap from="/spencer/sensors/rgbd_front_top/depth/camera_info" to="/spencer/sensors/rgbd_front_top/depth_registered/camera_info" if="$(arg use_openni1)"/>
 
         <include file="$(find spencer_people_tracking_launch)/launch/detectors/front_rgbd_detectors.launch">


### PR DESCRIPTION
The following snippet fixes the remapping for open ni 1, allowing for the rectified depth image to be caught by spencer and allowing for detections to be published/visible in rviz when launched with the ```use_openni1:=true``` flag.

```
<remap from="/spencer/sensors/rgbd_front_top/depth/image_rect" to="/spencer/sensors/rgbd_front_top/depth_registered/hw_registered/image_rect"  if="$(arg use_openni1)"/>
```

Tested with a Kinect v1 on the PrimeSense(SensorKinect) middleware on OpenNI 1.

Specifically, the command to launch was: ```roslaunch spencer_people_tracking_launch tracking_single_rgbd_sensor.launch height_above_ground:=1.6 use_openni1:=true```

This fixes the following issue that was closed prematurely: https://github.com/spencer-project/spencer_people_tracking/issues/50

![openni1_working](https://user-images.githubusercontent.com/7205959/38844414-5b6be2f0-41c1-11e8-9310-b1ad6af4adad.png)

