### PR TITLE
Update Makefile to fix docker build error

### DIFF
--- a/.docker/Makefile
+++ b/.docker/Makefile
@@ -11,10 +11,10 @@ help:
 	@echo ""
 
 build:
-		cd .. && \
-		docker build --tag=spencer/spencer_people_tracking:noetic --file=.docker/noetic/Dockerfile
+	cd .. && \
+	docker build --tag=spencer/spencer_people_tracking:noetic --file=.docker/noetic/Dockerfile .
 
 build_gpu:
- 		cd .. && \
-		docker build --tag=spencer/spencer_people_tracking:noetic-gpu --file=.docker/noetic-gpu/Dockerfile .
+	cd .. && \
+	docker build --tag=spencer/spencer_people_tracking:noetic-gpu --file=.docker/noetic-gpu/Dockerfile .
 


### PR DESCRIPTION
Before this bug fix, we may encounter the docker build error when building noetic image.