### PR TITLE
Fix leg_detector topic

### DIFF
--- a/detection/laser_detectors/spencer_leg_detector_wrapper/launch/leg_detector.launch
+++ b/detection/laser_detectors/spencer_leg_detector_wrapper/launch/leg_detector.launch
@@ -23,10 +23,9 @@
             <param name="use_object_id" value="false"/>
             <param name="cov_scale" value="$(arg cov_scale)"/>
 
-            <!-- FIXME: I believe the target topic should be people_tracker_measurements (=fused), otherwise we get one
-                 detection per single leg, leading to duplicate person tracks. Couldn't test this on SPENCER data, as our
-                 sensor is mounted too high to discriminate between two legs of a person. -->
-            <remap from="/position_measurements" to="leg_tracker_measurements"/>
+            <!-- Needs to be people_tracker_measurements (=fused) for people detections.
+                 If you want to track individual legs, use leg_tracker_measurements instead. -->
+            <remap from="/position_measurements" to="people_tracker_measurements"/>
             <remap from="/spencer/perception/detected_persons" to="$(arg detected_persons)"/>
         </node>
     </group>


### PR DESCRIPTION
As the original comment already suggests, "people_tracker_measurements" needs to be used to track people and not "leg_tracker_measurements" which contains individual legs. Please also include this in the other branches (kinetic, melodic, ...).