### PR TITLE
messages: removed unneeded dependencies

### DIFF
--- a/messages/spencer_control_msgs/CMakeLists.txt
+++ b/messages/spencer_control_msgs/CMakeLists.txt
@@ -2,8 +2,6 @@ cmake_minimum_required(VERSION 2.8.3)
 project(spencer_control_msgs)
 
 find_package(catkin REQUIRED COMPONENTS
-  roscpp
-  roslib
   std_msgs
   message_generation
 )
@@ -28,5 +26,5 @@ generate_messages(
 ## catkin specific configuration ##
 ###################################
 catkin_package(
-  CATKIN_DEPENDS roscpp std_msgs message_runtime
+  CATKIN_DEPENDS std_msgs message_runtime
 )

--- a/messages/spencer_control_msgs/package.xml
+++ b/messages/spencer_control_msgs/package.xml
@@ -12,11 +12,9 @@
 
   <buildtool_depend>catkin</buildtool_depend>
   <build_depend>message_generation</build_depend>
-  <build_depend>roscpp</build_depend>
   <build_depend>std_msgs</build_depend>
   
   <run_depend>message_runtime</run_depend>
-  <run_depend>roscpp</run_depend>
   <run_depend>std_msgs</run_depend>
 
-<build_depend>roslib</build_depend><run_depend>roslib</run_depend></package>
+</package>

--- a/messages/spencer_human_attribute_msgs/CMakeLists.txt
+++ b/messages/spencer_human_attribute_msgs/CMakeLists.txt
@@ -2,8 +2,6 @@ cmake_minimum_required(VERSION 2.8.3)
 project(spencer_human_attribute_msgs)
 
 find_package(catkin REQUIRED COMPONENTS
-  roscpp
-  roslib
   std_msgs
   message_generation
 )
@@ -35,5 +33,5 @@ generate_messages(
 ## catkin specific configuration ##
 ###################################
 catkin_package(
-  CATKIN_DEPENDS roscpp std_msgs message_runtime 
+  CATKIN_DEPENDS std_msgs message_runtime 
 )

--- a/messages/spencer_human_attribute_msgs/package.xml
+++ b/messages/spencer_human_attribute_msgs/package.xml
@@ -12,11 +12,9 @@
 
   <buildtool_depend>catkin</buildtool_depend>
   <build_depend>message_generation</build_depend>
-  <build_depend>roscpp</build_depend>
   <build_depend>std_msgs</build_depend>
   
   <run_depend>message_runtime</run_depend>
-  <run_depend>roscpp</run_depend>
   <run_depend>std_msgs</run_depend>
 
-<build_depend>roslib</build_depend><run_depend>roslib</run_depend></package>
+</package>

--- a/messages/spencer_social_relation_msgs/CMakeLists.txt
+++ b/messages/spencer_social_relation_msgs/CMakeLists.txt
@@ -2,8 +2,6 @@ cmake_minimum_required(VERSION 2.8.3)
 project(spencer_social_relation_msgs)
 
 find_package(catkin REQUIRED COMPONENTS
-  roscpp
-  roslib
   std_msgs
   sensor_msgs
   nav_msgs
@@ -42,5 +40,5 @@ generate_messages(
 ## catkin specific configuration ##
 ###################################
 catkin_package(
-  CATKIN_DEPENDS roscpp std_msgs sensor_msgs nav_msgs geometry_msgs message_runtime 
+  CATKIN_DEPENDS std_msgs sensor_msgs nav_msgs geometry_msgs message_runtime 
 )

--- a/messages/spencer_social_relation_msgs/package.xml
+++ b/messages/spencer_social_relation_msgs/package.xml
@@ -12,17 +12,15 @@
 
   <buildtool_depend>catkin</buildtool_depend>
   <build_depend>message_generation</build_depend>
-  <build_depend>roscpp</build_depend>
   <build_depend>std_msgs</build_depend>
   <build_depend>sensor_msgs</build_depend>
   <build_depend>nav_msgs</build_depend>
   <build_depend>geometry_msgs</build_depend>
   
   <run_depend>message_runtime</run_depend>
-  <run_depend>roscpp</run_depend>
   <run_depend>std_msgs</run_depend>
   <run_depend>sensor_msgs</run_depend>
   <run_depend>nav_msgs</run_depend>
   <run_depend>geometry_msgs</run_depend>
 
-<build_depend>roslib</build_depend><run_depend>roslib</run_depend></package>
+</package>

--- a/messages/spencer_tracking_msgs/CMakeLists.txt
+++ b/messages/spencer_tracking_msgs/CMakeLists.txt
@@ -2,8 +2,6 @@ cmake_minimum_required(VERSION 2.8.3)
 project(spencer_tracking_msgs)
 
 find_package(catkin REQUIRED COMPONENTS
-  roscpp
-  roslib
   std_msgs
   geometry_msgs
   message_generation
@@ -48,5 +46,5 @@ generate_messages(
 ## catkin specific configuration ##
 ###################################
 catkin_package(
-  CATKIN_DEPENDS roscpp std_msgs geometry_msgs message_runtime 
+  CATKIN_DEPENDS std_msgs geometry_msgs message_runtime 
 )

--- a/messages/spencer_tracking_msgs/package.xml
+++ b/messages/spencer_tracking_msgs/package.xml
@@ -17,13 +17,11 @@
   
   <buildtool_depend>catkin</buildtool_depend>
   <build_depend>message_generation</build_depend>
-  <build_depend>roscpp</build_depend>
   <build_depend>std_msgs</build_depend>
   <build_depend>geometry_msgs</build_depend>
   
   <run_depend>message_runtime</run_depend>
-  <run_depend>roscpp</run_depend>
   <run_depend>std_msgs</run_depend>
   <run_depend>geometry_msgs</run_depend>
   
-<build_depend>roslib</build_depend><run_depend>roslib</run_depend></package>
+</package>

--- a/messages/spencer_vision_msgs/CMakeLists.txt
+++ b/messages/spencer_vision_msgs/CMakeLists.txt
@@ -2,8 +2,6 @@ cmake_minimum_required(VERSION 2.8.3)
 project(spencer_vision_msgs)
 
 find_package(catkin REQUIRED COMPONENTS
-  roscpp
-  roslib
   std_msgs
   sensor_msgs
   geometry_msgs
@@ -40,5 +38,5 @@ generate_messages(
 ## catkin specific configuration ##
 ###################################
 catkin_package(
-  CATKIN_DEPENDS roscpp std_msgs sensor_msgs geometry_msgs message_runtime 
+  CATKIN_DEPENDS std_msgs sensor_msgs geometry_msgs message_runtime 
 )

--- a/messages/spencer_vision_msgs/package.xml
+++ b/messages/spencer_vision_msgs/package.xml
@@ -17,15 +17,13 @@
 
   <buildtool_depend>catkin</buildtool_depend>
   <build_depend>message_generation</build_depend>
-  <build_depend>roscpp</build_depend>
   <build_depend>std_msgs</build_depend>
   <build_depend>geometry_msgs</build_depend>
   <build_depend>sensor_msgs</build_depend>
   
   <run_depend>message_runtime</run_depend>
-  <run_depend>roscpp</run_depend>
   <run_depend>std_msgs</run_depend>
   <run_depend>geometry_msgs</run_depend>
   <run_depend>sensor_msgs</run_depend>
 
-<build_depend>roslib</build_depend><run_depend>roslib</run_depend></package>
+</package>


### PR DESCRIPTION
Messages packages don't need roscpp or roslib since they just need to be
able to generate the messages. The actual code packages that use these
has dependencies on them and will cause them to be pulled in as needed.
When building roscpp has been added to the catkin workspace rebuilding
just the message packages were blocked by waiting on roscpp, which would
significantly increase the amount of time needed just to rebuild the
message packages.